### PR TITLE
CI: Adding CI check for linted files. If a PR is open with code that …

### DIFF
--- a/.github/workflows/linter_check.yaml
+++ b/.github/workflows/linter_check.yaml
@@ -1,0 +1,33 @@
+name: Code Style Check
+# If your code has failed this workflow, you need to install the pre-commit hooks and run `pixi run pre-commit run --all-files`, adding and committing those changes.
+# Please see docs/setup.md for more information on installing and what the committing process looks like.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+env:
+  PYTHON_VERSION: "3.10"
+
+jobs:
+  Check-linter-status:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Run pre-commit hooks
+        run: pre-commit run --all-files --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         # supported by your project here, or alternatively use
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.11
+        language_version: python3.10
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:


### PR DESCRIPTION
…is not compliant with the linters, it will fail this status check. Please see comments in workflow or docs/setup.md for how to ensure your linters are installed and running on commit